### PR TITLE
Added pubsub package to graphql_ws

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     author="Syrus Akbary",
     author_email='me@syrusakbary.com',
     url='https://github.com/graphql-python/graphql-ws',
-    packages=find_packages(include=['graphql_ws']),
+    packages=find_packages(include=['graphql_ws','graphql_ws.pubsub']),
     include_package_data=True,
     install_requires=requirements,
     license="MIT license",


### PR DESCRIPTION
Pulling in your fork of graphql_ws via pip ignores pubsub package without its addition in setup.py. Breaks the example code for me as well.